### PR TITLE
Refactor: Core Run메소드 리펙토링

### DIFF
--- a/src/grc/core/Core.hpp
+++ b/src/grc/core/Core.hpp
@@ -29,13 +29,14 @@ public:
     Core(const int port, const std::string& password);
     ~Core();
 
+    bool Init();
     void Run();
+
 private:
     Core();
     Core(const Core& core); // = delete
     const Core& operator=(const Core& core); // = delete
 
-    bool init();
     bool initLog();
     void initConsoleWindow();
 
@@ -44,6 +45,9 @@ private:
     void inputToConsole();
     void excuteConsoleCommand();
     void logFileToConsole();
+
+    /* about connet client */
+    void acceptNewClients();
 
     /* about console print */
     bool isTimePassed(const int64 ms);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,9 +24,13 @@ int main(const int argc, const char **argv)
     }
     const int port = std::atoi(argv[1]);
     const std::string password(argv[2]);
-    grc::Core server(port, password);
 
-    server.Run();
+    {
+        grc::Core server(port, password);
 
+        server.Init();
+        
+        server.Run();
+    }
     return EXIT_SUCCESS;
 }

--- a/src/utils/ConsoleWindow.cpp
+++ b/src/utils/ConsoleWindow.cpp
@@ -113,7 +113,7 @@ bool ConsoleWindow::IsEOF() const
     else return false;
 }
 
-void ConsoleWindow::RefreshScreen()
+void ConsoleWindow::RefreshConsole()
 {
     updateConsoleSize();
     printClear();

--- a/src/utils/ConsoleWindow.hpp
+++ b/src/utils/ConsoleWindow.hpp
@@ -31,7 +31,7 @@ public:
     void Out(const std::string& str, const eANSIColor color = Default);
     bool IsEOF() const;
     
-    void RefreshScreen();
+    void RefreshConsole();
     void SetHeaderColor(const eANSIColor color);
     void SetFooterColor(const eANSIColor color);
     void SetHeader(const std::string& str);


### PR DESCRIPTION
- Run() Init() 구분하여 둘 다 퍼블릭 멤버 함수
- 새로운 클라이언트 연결하는 로직을 함수로 분리 -> acceptNewClient()
- 변경된 Core의 퍼블릭함수에 따라 main.cpp 수정
- ConsoleWindow class의 RefreshScreen() 함수명 변경 -> RefreshConsole()로