### PR TITLE
Refactor: Makefile, Core 리팩토링

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME		=	ircserv
 
 CXX			=	c++
-CXXFLAGS	=	-I./src	-I./extlibs/libbsd-gdf/include -MMD #-Wall -Wextra -Werror -std=c++98
+CXXFLAGS	=	-I./src	-I./extlibs/libbsd-gdf/include -MMD -Wall -Wextra -Werror -std=c++98
 
 LDFLAGS		=	-L./extlibs/libbsd-gdf/lib -Wl,-rpath,./extlibs/libbsd-gdf/lib
 LDLIBS		=	-lbsd-gdf-assert -lbsd-gdf-logger -lbsd-gdf-display -lbsd-gdf-network -lbsd-gdf-event
@@ -30,7 +30,6 @@ clean :
 	$(MAKE) clean -C extlibs/libbsd-gdf
 	$(RM) $(OBJS) $(DEPS)
 re :
-	$(MAKE) re -C extlibs/libbsd-gdf
 	$(MAKE) fclean
 	$(MAKE) all
 	

--- a/src/grc/core/Core.cpp
+++ b/src/grc/core/Core.cpp
@@ -5,7 +5,7 @@
 namespace grc
 {
 
-Core::Core(const int port, const std::string& password)
+Core::Core(const int IN port, const std::string& IN password)
 : mPort(port)
 , mPassword(password)
 , bRunning(false)
@@ -157,30 +157,6 @@ void Core::initConsoleWindow()
     mActivatedWindow = &mLogMonitor;
 }
 
-bool Core::identifyEvent(const struct kevent& event, const eEventType type, const int32 fd)
-{
-    if (event.ident == fd && event.filter == type)
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-bool Core::identifyEvent(const struct kevent& event, const eEventType type)
-{
-    if (event.filter == type)
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
 void Core::handleMonitorInput()
 {
     const char key = getchar();
@@ -299,33 +275,6 @@ void Core::setupNewClient()
         {
             LOG(LogLevel::Notice) << "Client(" << mNetwork.GetIPString(newClient) << ") connected";
         }
-    }
-}
-
-bool Core::isServerSocket(const struct kevent& event)
-{
-    if (event.ident == mNetwork.GetServerSocket())
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-bool Core::isClientSocket(const struct kevent& event)
-{
-    if (event.ident != mNetwork.GetServerSocket()
-        && event.ident != STDIN
-        && event.ident != STDOUT
-        && event.ident != mLogFileFD)
-    {
-        return true;
-    }
-    else
-    {
-        return false;
     }
 }
 

--- a/src/grc/core/Core.cpp
+++ b/src/grc/core/Core.cpp
@@ -259,7 +259,7 @@ void Core::handleLogBuffer()
     }
 
     mLogBufferIndex += wrote;
-    if (wrote == len)
+    if ((uint64)wrote == len)
     {
         mLogBuffer.clear();
         mLogBufferIndex = 0;

--- a/src/grc/core/Core.hpp
+++ b/src/grc/core/Core.hpp
@@ -25,7 +25,7 @@ namespace grc
 class Core
 {
 public:
-    Core(const int port, const std::string& password);
+    Core(const int IN port, const std::string& IN password);
     ~Core();
 
     bool Init();
@@ -43,7 +43,7 @@ private:
         STDOUT = STDOUT_FILENO
     };
 private:
-    Core();
+    Core(); // = delete
     Core(const Core& core); // = delete
     const Core& operator=(const Core& core); // = delete
 
@@ -51,18 +51,12 @@ private:
     void initConsoleWindow();
 
     /* about event */
-    bool identifyEvent(const struct kevent& event, const eEventType type, const int32 fd);
-    bool identifyEvent(const struct kevent& event, const eEventType type);
     void handleMonitorInput();
     void handleMonitorCommand();
     void handleLogBuffer();
 
     /* about network connection */
     void setupNewClient();
-
-    /* about idenfify network socket */
-    bool isServerSocket(const struct kevent& event);
-    bool isClientSocket(const struct kevent& event);
 
 private:
     const int mPort;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@
 #include "common.hpp"
 #include "grc/core/Core.hpp"
 
-int main(const int argc, const char **argv)
+int main(const int IN argc, const char** IN argv)
 {
     if (argc != 3
         || isInt(argv[1]) == false
@@ -27,9 +27,7 @@ int main(const int argc, const char **argv)
 
     {
         grc::Core server(port, password);
-
         server.Init();
-        
         server.Run();
     }
     return EXIT_SUCCESS;


### PR DESCRIPTION
- make re 수행시, 불필요한 과정 제거.
- Core::handleLogBuffer()에서, if((uint64)wrote == len) 으로 코드 변경.
  - wrote = uint64로 되어 있어서, 서로 다른 type간 비교로 컴파일 오류 발생.
  - 비교시에만 int64->uint64로 형변환 하도록 수정.